### PR TITLE
Update mgpucontext.cu

### DIFF
--- a/src/mgpucontext.cu
+++ b/src/mgpucontext.cu
@@ -229,10 +229,18 @@ CudaContext::CudaContext(CudaDevice& device, bool newStream, bool standard) :
 	_ownStream = newStream;
 
 	// Allocate 4KB of page-locked memory.
-	cudaMallocHost((void**)&_pageLocked, 4096);
+	cudaError_t error = cudaMallocHost((void**)&_pageLocked, 4096);
+	if(cudaSuccess != error) {
+		fprintf(stderr, "ERROR ALLOCATING PAGE-LOCKED MEMORY\n");
+		exit(0);
+        }
 
 	// Allocate an auxiliary stream.
-	cudaStreamCreate(&_auxStream);
+	error = cudaStreamCreate(&_auxStream);
+        if(cudaSuccess != error) {
+		fprintf(stderr, "ERROR ALLOCATING AUXILIARY STREAM\n");
+		exit(0);
+        }
 }
 
 CudaContext::~CudaContext() {

--- a/src/mgpucontext.cu
+++ b/src/mgpucontext.cu
@@ -229,10 +229,10 @@ CudaContext::CudaContext(CudaDevice& device, bool newStream, bool standard) :
 	_ownStream = newStream;
 
 	// Allocate 4KB of page-locked memory.
-	cudaError_t error = cudaMallocHost((void**)&_pageLocked, 4096);
+	cudaMallocHost((void**)&_pageLocked, 4096);
 
 	// Allocate an auxiliary stream.
-	error = cudaStreamCreate(&_auxStream);
+	cudaStreamCreate(&_auxStream);
 }
 
 CudaContext::~CudaContext() {


### PR DESCRIPTION
Variable is just used to store and is not being used for anything else, this will cause warnings and errors while compiling with options. Just to be safer side, it would be better without the variable.