### PR TITLE
Adding a #ifndef around MEMBERMASK to avoid redefinition.

### DIFF
--- a/include/device/intrinsics.cuh
+++ b/include/device/intrinsics.cuh
@@ -105,7 +105,9 @@ MGPU_DEVICE uint prmt_ptx(uint a, uint b, uint index) {
 ////////////////////////////////////////////////////////////////////////////////
 // shfl_up
 
-#define MEMBERMASK 0xffffffff
+#ifndef MEMBERMASK
+	#define MEMBERMASK 0xffffffff
+#endif
 
 __device__ __forceinline__ float shfl_up(float var, 
 	unsigned int delta, int width = 32, unsigned mask=MEMBERMASK) {


### PR DESCRIPTION
Libraries which include morderngpu and also have their own `shfl` intrinsics may run into compiler warnings for `MEMBERMASK`, this takes care of that.