### PR TITLE
Fix potential deadlock after switching to shfl.sync.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,6 @@
 # Generate SASS for important minor versions.
 # Generate PTX for the last named architecture for future support.
 ARCH=\
-  -gencode arch=compute_20,code=compute_20 \
-  -gencode arch=compute_20,code=sm_20 \
   -gencode arch=compute_35,code=compute_35 \
   -gencode arch=compute_35,code=sm_35 \
   -gencode arch=compute_52,code=compute_52 \

--- a/src/moderngpu/cta_segscan.hxx
+++ b/src/moderngpu/cta_segscan.hxx
@@ -36,7 +36,8 @@ struct cta_segscan_t {
     __syncthreads();
 
     if(tid < num_warps) {
-      int cta_bits = ballot(0 != storage.delta[tid]);
+      unsigned mask = __activemask();
+      int cta_bits = ballot(0 != storage.delta[tid], mask);
       int warp_segment = 31 - clz(cta_mask & cta_bits);
       int start = (-1 != warp_segment) ?
         (31 - clz(storage.delta[warp_segment]) + 32 * warp_segment) : 0;

--- a/src/moderngpu/intrinsics.hxx
+++ b/src/moderngpu/intrinsics.hxx
@@ -165,7 +165,7 @@ MGPU_HOST_DEVICE unsigned umulhi(unsigned a, unsigned b) {
 #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 300
 
 template<typename type_t>
-MGPU_DEVICE type_t shfl_up(type_t x, int offset, int width = warp_size) { 
+MGPU_DEVICE type_t shfl_up(type_t x, int offset, int width = warp_size, unsigned mask = MEMBERMASK) { 
   enum { num_words = div_up(sizeof(type_t), sizeof(int)) };
   union {
     int x[num_words];
@@ -175,7 +175,10 @@ MGPU_DEVICE type_t shfl_up(type_t x, int offset, int width = warp_size) {
 
   iterate<num_words>([&](int i) {
     #ifdef USE_SHFL_SYNC
-    u.x[i] = __shfl_up_sync(u.x[i], offset, width);
+    if (i < width) {
+      mask = __activemask();
+      u.x[i] = __shfl_up_sync(mask, u.x[i], offset);
+    }
     #else
     u.x[i] = __shfl_up(u.x[i], offset, width);
     #endif
@@ -184,7 +187,7 @@ MGPU_DEVICE type_t shfl_up(type_t x, int offset, int width = warp_size) {
 }
 
 template<typename type_t>
-MGPU_DEVICE type_t shfl_down(type_t x, int offset, int width = warp_size) { 
+MGPU_DEVICE type_t shfl_down(type_t x, int offset, int width = warp_size, unsigned mask = MEMBERMASK) { 
   enum { num_words = div_up(sizeof(type_t), sizeof(int)) };
   union {
     int x[num_words];
@@ -194,7 +197,10 @@ MGPU_DEVICE type_t shfl_down(type_t x, int offset, int width = warp_size) {
 
   iterate<num_words>([&](int i) {
     #ifdef USE_SHFL_SYNC
-    u.x[i] = __shfl_down_sync(u.x[i], offset, width);
+    if (i < width) {
+      mask = __activemask();
+      u.x[i] = __shfl_down_sync(mask, u.x[i], offset);
+    }
     #else
     u.x[i] = __shfl_down(u.x[i], offset, width);
     #endif
@@ -204,7 +210,7 @@ MGPU_DEVICE type_t shfl_down(type_t x, int offset, int width = warp_size) {
 
 template<typename type_t, typename op_t> 
 MGPU_DEVICE type_t shfl_up_op(type_t x, int offset, op_t op, 
-  int width = warp_size) {
+  int width = warp_size, unsigned mask = MEMBERMASK) {
 
   type_t y = shfl_up(x, offset, width);
   int lane = (width - 1) & threadIdx.x;
@@ -214,7 +220,7 @@ MGPU_DEVICE type_t shfl_up_op(type_t x, int offset, op_t op,
 
 template<typename type_t, typename op_t> 
 MGPU_DEVICE type_t shfl_down_op(type_t x, int offset, op_t op, 
-  int width = warp_size) {
+  int width = warp_size, unsigned mask = MEMBERMASK) {
 
   type_t y = shfl_down(x, offset, width);
   int lane = (width - 1) & threadIdx.x;
@@ -222,13 +228,15 @@ MGPU_DEVICE type_t shfl_down_op(type_t x, int offset, op_t op,
   return x;
 }
 
-
 #ifdef USE_SHFL_SYNC
 #define SHFL_OP_MACRO(dir, is_up, ptx_type, r, c_type, ptx_op, c_op) \
 MGPU_DEVICE inline c_type shfl_##dir##_op(c_type x, int offset, \
-  c_op<c_type> op, int width = warp_size, unsigned threadmask=MEMBERMASK) { \
-  c_type result = c_type(); \
+  c_op<c_type> op, int width = warp_size, unsigned fullmask=MEMBERMASK) { \
+  c_type result = x; \
   int mask = (warp_size - width)<< 8 | (is_up ? 0 : (width - 1)); \
+  int lane = threadIdx.x & (warp_size - 1); \
+  if (lane < width) { \
+  unsigned threadmask = __activemask(); \
   asm( \
     "{.reg ."#ptx_type" r0;" \
     ".reg .pred p;" \
@@ -236,6 +244,7 @@ MGPU_DEVICE inline c_type shfl_##dir##_op(c_type x, int offset, \
     "@p "#ptx_op"."#ptx_type" r0, r0, %5;" \
     "mov."#ptx_type" %0, r0; }" \
     : "="#r(result) : #r(x), "r"(offset), "r"(mask), "r"(threadmask), #r(x)); \
+  } \
   return result; \
 }
 #else
@@ -281,9 +290,12 @@ SHFL_OP_MACRO(down, false, f32, f, float, max, minimum_t)
 #ifdef USE_SHFL_SYNC
 #define SHFL_OP_64b_MACRO(dir, is_up, ptx_type, r, c_type, ptx_op, c_op) \
 MGPU_DEVICE inline c_type shfl_##dir##_op(c_type x, int offset, \
-  c_op<c_type> op, int width = warp_size, unsigned threadmask=MEMBERMASK) { \
-  c_type result = c_type(); \
+  c_op<c_type> op, int width = warp_size, unsigned fullmask=MEMBERMASK) { \
+  c_type result = x; \
   int mask = (warp_size - width)<< 8 | (is_up ? 0 : (width - 1)); \
+  int lane = threadIdx.x & (warp_size - 1); \
+  if (lane < width) { \
+  unsigned threadmask = __activemask(); \
   asm( \
     "{.reg ."#ptx_type" r0;" \
     ".reg .u32 lo;" \
@@ -297,6 +309,7 @@ MGPU_DEVICE inline c_type shfl_##dir##_op(c_type x, int offset, \
     "mov."#ptx_type" %0, r0; }" \
     : "="#r(result) : #r(x), "r"(offset), "r"(mask), "r"(threadmask), #r(x) \
   ); \
+  } \
   return result; \
 }
 #else


### PR DESCRIPTION
1 Use __activemask() to avoid potential deadlock.
2 Remove sm_20 related settings in Makefile.

Micro-benchmark on V100 and P40 show no performance regression after this. I did not do a thorough regression test though.

@seanbaxter Would you please take a look? Thanks!